### PR TITLE
Fix displaying badge in phpBB 3.1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ branches:
   only:
     - master
     - /^\d+(\.\d+)?\.x$/
+    - /^stable-\d+(\.\d+){1,2}-3\.1$/
 
 install:
   - travis/prepare-phpbb.sh $EXTNAME $PHPBB_BRANCH

--- a/styles/all/template/js/active-notifications.js
+++ b/styles/all/template/js/active-notifications.js
@@ -29,6 +29,9 @@ jQuery(function($) {
 			if (lastUnreadCount != data['unread']) {
 				lastUnreadCount = parseInt(data['unread']);
 				phpbb.markNotifications($(), lastUnreadCount);
+				if (lastUnreadCount) {
+					$('#notification_list_button > strong').removeClass('hidden');
+				}
 			}
 
 			// Add notifications


### PR DESCRIPTION
Starting with phpBB 3.1.11, if there are 0 notifications the number is hidden. When this extension loads new notifications, the number needs to be displayed by removing the `hidden` CSS class.