### PR TITLE
Fix hiding unread notifications number

### DIFF
--- a/styles/all/template/js/active-notifications.js
+++ b/styles/all/template/js/active-notifications.js
@@ -29,7 +29,7 @@ jQuery(function($) {
 			var newUnreadCount = parseInt(data['unread']);
 			if (lastUnreadCount !== newUnreadCount) {
 				phpbb.markNotifications($(), newUnreadCount);
-				$('#notification_list_button > strong').toggleClass('hidden', newUnreadCount);
+				$('#notification_list_button > strong').toggleClass('hidden', !newUnreadCount);
 				lastUnreadCount = newUnreadCount;
 			}
 


### PR DESCRIPTION
The unread notifications number gets hidden when a second new notification arrives. This small edit fixes the problem.