### PR TITLE
Fixed displaying ACP setting in phpBB 3.3

### DIFF
--- a/event/listener.php
+++ b/event/listener.php
@@ -123,7 +123,7 @@ class listener implements EventSubscriberInterface
 			];
 
 			$display_vars = $event['display_vars'];
-			$display_vars['vars'] = phpbb_insert_config_array($display_vars['vars'], $config, ['after' => 'load_cpf_viewtopic']);
+			$display_vars['vars'] = phpbb_insert_config_array($display_vars['vars'], $config, ['after' => 'allow_quick_reply']);
 			$event['display_vars'] = $display_vars;
 		}
 	}


### PR DESCRIPTION
In phpBB 3.3 the load settings have been removed from the ACP Board features page, which is what this extension's ACP settings depended on when adding them to the correct position.